### PR TITLE
update set env variables

### DIFF
--- a/set_env_variables.sh
+++ b/set_env_variables.sh
@@ -7,7 +7,11 @@ log() {
   COLOR_CYAN='\033[1;36m'
   echo -e "${COLOR_CYAN}$1${COLOR_DEFAULT}"
 }
-echo "pwd: `pwd`"
+
+# TODO:
+# #  SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+# doesn't work, throws bad substitution, it returns path to script (in this case aml
+# as a temporary hack I supply the SCRIPT DIR manually
 if [ -z ${SCRIPT_DIR+x} ]; then
 #  SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
   SCRIPT_DIR=`pwd`

--- a/set_env_variables.sh
+++ b/set_env_variables.sh
@@ -45,7 +45,7 @@ if [ "${ARCH}" = "aarch64" ]; then
    python3 $SCRIPT_DIR/utils/setup/gen_ld_preload.py
    LD_PRELOAD=`cat $SCRIPT_DIR/utils/setup/.ld_preload`
    # add this path manually, due to the fact that python doesn't find it. (temporary hack?)
-   LD_PRELOAD=$LD_PRELOAD:/root/miniforge3/envs/tensorflow/lib/python3.8/site-packages/skimage/_shared/../../scikit_image.libs/libgomp-d22c30c5.so.1.0.0
+#   LD_PRELOAD=$LD_PRELOAD:/root/miniforge3/envs/tensorflow/lib/python3.8/site-packages/skimage/_shared/../../scikit_image.libs/libgomp-d22c30c5.so.1.0.0
    echo "LD_PRELOAD=$LD_PRELOAD"
 fi
 export LD_PRELOAD=$LD_PRELOAD

--- a/set_env_variables.sh
+++ b/set_env_variables.sh
@@ -30,7 +30,7 @@ fi
 
 #echo $SCRIPT_DIR
 #SCRIPT_DIR=$SCRIPT_DIR/ampere_model_library
-#echo $SCRIPT_DIR
+echo $SCRIPT_DIR
 
 
 log "Checking if setup has been completed ..."

--- a/set_env_variables.sh
+++ b/set_env_variables.sh
@@ -20,10 +20,15 @@ log() {
 #fi
 
 # checks if IS_JENKINS has length equal to zero
-if [[ -z "${IS_JENKINS}" ]]; then
-  SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-else
-  SCRIPT_DIR=`pwd`/ampere_model_library
+#if [[ -z "${IS_JENKINS}" ]]; then
+#  SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+#else
+#  SCRIPT_DIR=`pwd`/ampere_model_library
+#fi
+
+# if SCRIPT_DIR has length equal to zero
+if [[ -z "${SCRIPT_DIR}" ]]; then
+  SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 fi
 
 log "Checking if setup has been completed ..."
@@ -47,10 +52,6 @@ log "Setting environment variables ..."
 sleep 1
 ARCH=$( uname -m )
 if [ "${ARCH}" = "aarch64" ]; then
-   python3 $SCRIPT_DIR/utils/setup/gen_ld_preload.py
-   LD_PRELOAD=`cat $SCRIPT_DIR/utils/setup/.ld_preload`
-   echo "LD_PRELOAD=$LD_PRELOAD"
-else
    python3 $SCRIPT_DIR/utils/setup/gen_ld_preload.py
    LD_PRELOAD=`cat $SCRIPT_DIR/utils/setup/.ld_preload`
    echo "LD_PRELOAD=$LD_PRELOAD"

--- a/set_env_variables.sh
+++ b/set_env_variables.sh
@@ -43,10 +43,9 @@ sleep 1
 ARCH=$( uname -m )
 if [ "${ARCH}" = "aarch64" ]; then
    python3 $SCRIPT_DIR/utils/setup/gen_ld_preload.py
-#   LD_PRELOAD=`cat $SCRIPT_DIR/utils/setup/.ld_preload`
+   LD_PRELOAD=`cat $SCRIPT_DIR/utils/setup/.ld_preload`
    # add this path manually, due to the fact that python doesn't find it. (temporary hack?)
-#   LD_PRELOAD=$LD_PRELOAD:/root/miniforge3/envs/tensorflow/lib/python3.8/site-packages/skimage/_shared/../../scikit_image.libs/libgomp-d22c30c5.so.1.0.0
-   LD_PRELOAD=/root/miniforge3/envs/tensorflow/lib/python3.8/site-packages/skimage/_shared/../../scikit_image.libs/libgomp-d22c30c5.so.1.0.0
+   LD_PRELOAD=$LD_PRELOAD:/root/miniforge3/envs/tensorflow/lib/python3.8/site-packages/skimage/_shared/../../scikit_image.libs/libgomp-d22c30c5.so.1.0.0
    echo "LD_PRELOAD=$LD_PRELOAD"
 fi
 export LD_PRELOAD=$LD_PRELOAD

--- a/set_env_variables.sh
+++ b/set_env_variables.sh
@@ -58,7 +58,7 @@ if [ "${ARCH}" = "aarch64" ]; then
    python3 $SCRIPT_DIR/utils/setup/gen_ld_preload.py
    LD_PRELOAD=$(<$SCRIPT_DIR/utils/setup/.ld_preload)
    cat $SCRIPT_DIR/utils/setup/.ld_preload
-   export LD_PRELOAD=$LD_PRELOAD
+#   export LD_PRELOAD=$LD_PRELOAD
    echo "LD_PRELOAD=$LD_PRELOAD"
 fi
 export PYTHONPATH=$SCRIPT_DIR

--- a/set_env_variables.sh
+++ b/set_env_variables.sh
@@ -12,15 +12,20 @@ log() {
 # #  SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 # doesn't work, throws bad substitution, it returns path to script (in this case aml
 # as a temporary hack I supply the SCRIPT DIR manually
-if [ -z ${SCRIPT_DIR+x} ]; then
-#  SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+#if [ -z ${SCRIPT_DIR+x} ]; then
+##  SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+#  SCRIPT_DIR=`pwd`
+#fi
+
+if [[ -z "${JENKINS}" ]]; then
+  # JENKINS is undefined
+  if [ -z ${SCRIPT_DIR+x} ]; then
+  SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+  fi
+else
   SCRIPT_DIR=`pwd`
 fi
 
-#if [ $# -eq 0 ]
-#  then
-#    echo "No arguments supplied"
-#fi
 
 echo $SCRIPT_DIR
 SCRIPT_DIR=$SCRIPT_DIR/ampere_model_library

--- a/set_env_variables.sh
+++ b/set_env_variables.sh
@@ -24,12 +24,13 @@ if [[ -z "${JENKINS}" ]]; then
   fi
 else
   SCRIPT_DIR=`pwd`
+  SCRIPT_DIR=$SCRIPT_DIR/ampere_model_library
 fi
 
 
-echo $SCRIPT_DIR
-SCRIPT_DIR=$SCRIPT_DIR/ampere_model_library
-echo $SCRIPT_DIR
+#echo $SCRIPT_DIR
+#SCRIPT_DIR=$SCRIPT_DIR/ampere_model_library
+#echo $SCRIPT_DIR
 
 
 log "Checking if setup has been completed ..."

--- a/set_env_variables.sh
+++ b/set_env_variables.sh
@@ -7,7 +7,7 @@ log() {
   COLOR_CYAN='\033[1;36m'
   echo -e "${COLOR_CYAN}$1${COLOR_DEFAULT}"
 }
-
+echo $BASH_SOURCE[0]
 if [ -z ${SCRIPT_DIR+x} ]; then
   SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 fi

--- a/set_env_variables.sh
+++ b/set_env_variables.sh
@@ -9,7 +9,8 @@ log() {
 }
 echo "pwd: `pwd`"
 if [ -z ${SCRIPT_DIR+x} ]; then
-  SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+#  SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+  SCRIPT_DIR=`pwd`
 fi
 
 echo $SCRIPT_DIR

--- a/set_env_variables.sh
+++ b/set_env_variables.sh
@@ -56,8 +56,9 @@ sleep 1
 ARCH=$( uname -m )
 if [ "${ARCH}" = "aarch64" ]; then
    python3 $SCRIPT_DIR/utils/setup/gen_ld_preload.py
-   LD_PRELOAD=$(<$SCRIPT_DIR/utils/setup/.ld_preload)
-   cat $SCRIPT_DIR/utils/setup/.ld_preload
+#   LD_PRELOAD=$(<$SCRIPT_DIR/utils/setup/.ld_preload)
+   TEST=`cat $SCRIPT_DIR/utils/setup/.ld_preload`
+   echo "TEST=$TEST"
 #   export LD_PRELOAD=$LD_PRELOAD
    echo "LD_PRELOAD=$LD_PRELOAD"
 fi

--- a/set_env_variables.sh
+++ b/set_env_variables.sh
@@ -50,6 +50,10 @@ if [ "${ARCH}" = "aarch64" ]; then
    python3 $SCRIPT_DIR/utils/setup/gen_ld_preload.py
    LD_PRELOAD=`cat $SCRIPT_DIR/utils/setup/.ld_preload`
    echo "LD_PRELOAD=$LD_PRELOAD"
+else
+   python3 $SCRIPT_DIR/utils/setup/gen_ld_preload.py
+   LD_PRELOAD=`cat $SCRIPT_DIR/utils/setup/.ld_preload`
+   echo "LD_PRELOAD=$LD_PRELOAD"
 fi
 export LD_PRELOAD=$LD_PRELOAD
 export PYTHONPATH=$SCRIPT_DIR

--- a/set_env_variables.sh
+++ b/set_env_variables.sh
@@ -27,13 +27,10 @@ log() {
 #fi
 
 # if SCRIPT_DIR has length equal to zero
-echo SCRIPT_DIR=$SCRIPT_DIR
 if [ -z ${SCRIPT_DIR+x} ]; then
-  echo HERE111
   SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 fi
 
-echo SCRIPT_DIR=$SCRIPT_DIR
 log "Checking if setup has been completed ..."
 sleep 1
 if ! [ -f "$SCRIPT_DIR/.setup_completed" ]; then

--- a/set_env_variables.sh
+++ b/set_env_variables.sh
@@ -17,6 +17,11 @@ if [ -z ${SCRIPT_DIR+x} ]; then
   SCRIPT_DIR=`pwd`
 fi
 
+#if [ $# -eq 0 ]
+#  then
+#    echo "No arguments supplied"
+#fi
+
 echo $SCRIPT_DIR
 SCRIPT_DIR=$SCRIPT_DIR/ampere_model_library
 echo $SCRIPT_DIR

--- a/set_env_variables.sh
+++ b/set_env_variables.sh
@@ -17,6 +17,7 @@ log() {
 #  SCRIPT_DIR=`pwd`
 #fi
 
+# if the script is run with Jenkins, then set the SCRIPT_DIR manually, otherwise use the old way (does this work?)
 if [[ -z "${JENKINS}" ]]; then
   # JENKINS is undefined
   if [ -z ${SCRIPT_DIR+x} ]; then

--- a/set_env_variables.sh
+++ b/set_env_variables.sh
@@ -14,6 +14,8 @@ if [ -z ${SCRIPT_DIR+x} ]; then
 fi
 
 echo $SCRIPT_DIR
+SCRIPT_DIR=$SCRIPT_DIR/ampere_model_library
+echo $SCRIPT_DIR
 
 
 log "Checking if setup has been completed ..."

--- a/set_env_variables.sh
+++ b/set_env_variables.sh
@@ -10,7 +10,7 @@ log() {
 echo $BASH_SOURCE[0]
 echo $SCRIPT_DIR
 if [ -z ${SCRIPT_DIR+x} ]; then
-  SCRIPT_DIR=$( cd -- "$( dirname -- "$(BASH_SOURCE[0])" )" &> /dev/null && pwd )
+  SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 fi
 
 log "Checking if setup has been completed ..."

--- a/set_env_variables.sh
+++ b/set_env_variables.sh
@@ -27,7 +27,9 @@ log() {
 #fi
 
 # if SCRIPT_DIR has length equal to zero
+echo $SCRIPT_DIR
 if [[ -z "${SCRIPT_DIR}" ]]; then
+  echo $SCRIPT_DIR
   SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 fi
 

--- a/set_env_variables.sh
+++ b/set_env_variables.sh
@@ -10,7 +10,7 @@ log() {
 echo $BASH_SOURCE[0]
 echo $SCRIPT_DIR
 if [ -z ${SCRIPT_DIR+x} ]; then
-  SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+  SCRIPT_DIR=$( cd -- "$( dirname -- "$(BASH_SOURCE[0])" )" &> /dev/null && pwd )
 fi
 
 log "Checking if setup has been completed ..."

--- a/set_env_variables.sh
+++ b/set_env_variables.sh
@@ -44,8 +44,6 @@ ARCH=$( uname -m )
 if [ "${ARCH}" = "aarch64" ]; then
    python3 $SCRIPT_DIR/utils/setup/gen_ld_preload.py
    LD_PRELOAD=`cat $SCRIPT_DIR/utils/setup/.ld_preload`
-   # add this path manually, due to the fact that python doesn't find it. (temporary hack?)
-#   LD_PRELOAD=$LD_PRELOAD:/root/miniforge3/envs/tensorflow/lib/python3.8/site-packages/skimage/_shared/../../scikit_image.libs/libgomp-d22c30c5.so.1.0.0
    echo "LD_PRELOAD=$LD_PRELOAD"
 fi
 export LD_PRELOAD=$LD_PRELOAD

--- a/set_env_variables.sh
+++ b/set_env_variables.sh
@@ -29,6 +29,7 @@ log() {
 # if SCRIPT_DIR has length equal to zero
 echo SCRIPT_DIR=$SCRIPT_DIR
 if [ -z ${SCRIPT_DIR+x} ]; then
+  echo HERE111
   SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 fi
 

--- a/set_env_variables.sh
+++ b/set_env_variables.sh
@@ -27,12 +27,12 @@ log() {
 #fi
 
 # if SCRIPT_DIR has length equal to zero
-echo $SCRIPT_DIR
-if [[ -z "${SCRIPT_DIR}" ]]; then
+echo SCRIPT_DIR=$SCRIPT_DIR
+if [ -z ${SCRIPT_DIR+x} ]; then
   SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 fi
 
-echo $SCRIPT_DIR
+echo SCRIPT_DIR=$SCRIPT_DIR
 log "Checking if setup has been completed ..."
 sleep 1
 if ! [ -f "$SCRIPT_DIR/.setup_completed" ]; then

--- a/set_env_variables.sh
+++ b/set_env_variables.sh
@@ -27,10 +27,12 @@ log() {
 #fi
 
 # if SCRIPT_DIR has length equal to zero
+echo $SCRIPT_DIR
 if [[ -z "${SCRIPT_DIR}" ]]; then
   SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 fi
 
+echo $SCRIPT_DIR
 log "Checking if setup has been completed ..."
 sleep 1
 if ! [ -f "$SCRIPT_DIR/.setup_completed" ]; then

--- a/set_env_variables.sh
+++ b/set_env_variables.sh
@@ -49,6 +49,7 @@ if [ "${ARCH}" = "aarch64" ]; then
    LD_PRELOAD=/root/miniforge3/envs/tensorflow/lib/python3.8/site-packages/skimage/_shared/../../scikit_image.libs/libgomp-d22c30c5.so.1.0.0
    echo "LD_PRELOAD=$LD_PRELOAD"
 fi
+export LD_PRELOAD=$LD_PRELOAD
 export PYTHONPATH=$SCRIPT_DIR
 echo "PYTHONPATH=$PYTHONPATH"
 log "done.\n"

--- a/set_env_variables.sh
+++ b/set_env_variables.sh
@@ -8,7 +8,7 @@ log() {
   echo -e "${COLOR_CYAN}$1${COLOR_DEFAULT}"
 }
 
-# if the script is run with Jenkins, then set the SCRIPT_DIR manually, otherwise use the old way
+# if the script is run with Jenkins, then set the SCRIPT_DIR manually, otherwise use the old way (SET JENKINS TO 1)
 if [[ -z "${JENKINS}" ]]; then
   # not run with JENKINS
   if [ -z ${SCRIPT_DIR+x} ]; then
@@ -43,9 +43,10 @@ sleep 1
 ARCH=$( uname -m )
 if [ "${ARCH}" = "aarch64" ]; then
    python3 $SCRIPT_DIR/utils/setup/gen_ld_preload.py
-   LD_PRELOAD=`cat $SCRIPT_DIR/utils/setup/.ld_preload`
+#   LD_PRELOAD=`cat $SCRIPT_DIR/utils/setup/.ld_preload`
    # add this path manually, due to the fact that python doesn't find it. (temporary hack?)
-   LD_PRELOAD=$LD_PRELOAD:/root/miniforge3/envs/tensorflow/lib/python3.8/site-packages/skimage/_shared/../../scikit_image.libs/libgomp-d22c30c5.so.1.0.0
+#   LD_PRELOAD=$LD_PRELOAD:/root/miniforge3/envs/tensorflow/lib/python3.8/site-packages/skimage/_shared/../../scikit_image.libs/libgomp-d22c30c5.so.1.0.0
+   LD_PRELOAD=/root/miniforge3/envs/tensorflow/lib/python3.8/site-packages/skimage/_shared/../../scikit_image.libs/libgomp-d22c30c5.so.1.0.0
    echo "LD_PRELOAD=$LD_PRELOAD"
 fi
 export PYTHONPATH=$SCRIPT_DIR

--- a/set_env_variables.sh
+++ b/set_env_variables.sh
@@ -27,9 +27,7 @@ log() {
 #fi
 
 # if SCRIPT_DIR has length equal to zero
-echo $SCRIPT_DIR
 if [[ -z "${SCRIPT_DIR}" ]]; then
-  echo $SCRIPT_DIR
   SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 fi
 

--- a/set_env_variables.sh
+++ b/set_env_variables.sh
@@ -57,8 +57,7 @@ ARCH=$( uname -m )
 if [ "${ARCH}" = "aarch64" ]; then
    python3 $SCRIPT_DIR/utils/setup/gen_ld_preload.py
 #   LD_PRELOAD=$(<$SCRIPT_DIR/utils/setup/.ld_preload)
-   TEST=`cat $SCRIPT_DIR/utils/setup/.ld_preload`
-   echo "TEST=$TEST"
+   LD_PRELOAD=`cat $SCRIPT_DIR/utils/setup/.ld_preload`
 #   export LD_PRELOAD=$LD_PRELOAD
    echo "LD_PRELOAD=$LD_PRELOAD"
 fi

--- a/set_env_variables.sh
+++ b/set_env_variables.sh
@@ -7,11 +7,12 @@ log() {
   COLOR_CYAN='\033[1;36m'
   echo -e "${COLOR_CYAN}$1${COLOR_DEFAULT}"
 }
-echo $BASH_SOURCE[0]
-echo $SCRIPT_DIR
+
 if [ -z ${SCRIPT_DIR+x} ]; then
   SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 fi
+
+echo $SCRIPT_DIR
 
 log "Checking if setup has been completed ..."
 sleep 1

--- a/set_env_variables.sh
+++ b/set_env_variables.sh
@@ -8,6 +8,7 @@ log() {
   echo -e "${COLOR_CYAN}$1${COLOR_DEFAULT}"
 }
 echo $BASH_SOURCE[0]
+echo $SCRIPT_DIR
 if [ -z ${SCRIPT_DIR+x} ]; then
   SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 fi

--- a/set_env_variables.sh
+++ b/set_env_variables.sh
@@ -7,12 +7,13 @@ log() {
   COLOR_CYAN='\033[1;36m'
   echo -e "${COLOR_CYAN}$1${COLOR_DEFAULT}"
 }
-
+echo "pwd: `pwd`"
 if [ -z ${SCRIPT_DIR+x} ]; then
   SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 fi
 
 echo $SCRIPT_DIR
+
 
 log "Checking if setup has been completed ..."
 sleep 1

--- a/set_env_variables.sh
+++ b/set_env_variables.sh
@@ -56,9 +56,9 @@ sleep 1
 ARCH=$( uname -m )
 if [ "${ARCH}" = "aarch64" ]; then
    python3 $SCRIPT_DIR/utils/setup/gen_ld_preload.py
-#   LD_PRELOAD=$(<$SCRIPT_DIR/utils/setup/.ld_preload)
    LD_PRELOAD=`cat $SCRIPT_DIR/utils/setup/.ld_preload`
-#   export LD_PRELOAD=$LD_PRELOAD
+   # add this path manually, due to the fact that python doesn't find it. (temporary hack?)
+   LD_PRELOAD=$LD_PRELOAD:/root/miniforge3/envs/tensorflow/lib/python3.8/site-packages/skimage/_shared/../../scikit_image.libs/libgomp-d22c30c5.so.1.0.0
    echo "LD_PRELOAD=$LD_PRELOAD"
 fi
 export PYTHONPATH=$SCRIPT_DIR

--- a/set_env_variables.sh
+++ b/set_env_variables.sh
@@ -8,25 +8,6 @@ log() {
   echo -e "${COLOR_CYAN}$1${COLOR_DEFAULT}"
 }
 
-# if the script is run with Jenkins, then set the SCRIPT_DIR manually, otherwise use the old way (SET JENKINS TO 1)
-#if [[ -z "${JENKINS}" ]]; then
-#   not run with JENKINS
-#  if [ -z ${SCRIPT_DIR+x} ]; then
-#    SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-#  fi
-#else
-  # run with JENKINS, need to set the SCRIPT_DIR in a different way, more manually
-#  SCRIPT_DIR=`pwd`/ampere_model_library
-#fi
-
-# checks if IS_JENKINS has length equal to zero
-#if [[ -z "${IS_JENKINS}" ]]; then
-#  SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-#else
-#  SCRIPT_DIR=`pwd`/ampere_model_library
-#fi
-
-# if SCRIPT_DIR has length equal to zero
 if [ -z ${SCRIPT_DIR+x} ]; then
   SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 fi

--- a/set_env_variables.sh
+++ b/set_env_variables.sh
@@ -9,17 +9,22 @@ log() {
 }
 
 # if the script is run with Jenkins, then set the SCRIPT_DIR manually, otherwise use the old way (SET JENKINS TO 1)
-if [[ -z "${JENKINS}" ]]; then
-  # not run with JENKINS
-  if [ -z ${SCRIPT_DIR+x} ]; then
-  SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-  fi
-else
+#if [[ -z "${JENKINS}" ]]; then
+#   not run with JENKINS
+#  if [ -z ${SCRIPT_DIR+x} ]; then
+#    SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+#  fi
+#else
   # run with JENKINS, need to set the SCRIPT_DIR in a different way, more manually
-  SCRIPT_DIR=`pwd`
-  SCRIPT_DIR=$SCRIPT_DIR/ampere_model_library
-fi
+#  SCRIPT_DIR=`pwd`/ampere_model_library
+#fi
 
+# checks if IS_JENKINS has length equal to zero
+if [[ -z "${IS_JENKINS}" ]]; then
+  SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+else
+  SCRIPT_DIR=`pwd`/ampere_model_library
+fi
 
 log "Checking if setup has been completed ..."
 sleep 1

--- a/set_env_variables.sh
+++ b/set_env_variables.sh
@@ -57,6 +57,7 @@ ARCH=$( uname -m )
 if [ "${ARCH}" = "aarch64" ]; then
    python3 $SCRIPT_DIR/utils/setup/gen_ld_preload.py
    LD_PRELOAD=$(<$SCRIPT_DIR/utils/setup/.ld_preload)
+   cat $SCRIPT_DIR/utils/setup/.ld_preload
    export LD_PRELOAD=$LD_PRELOAD
    echo "LD_PRELOAD=$LD_PRELOAD"
 fi

--- a/set_env_variables.sh
+++ b/set_env_variables.sh
@@ -8,30 +8,17 @@ log() {
   echo -e "${COLOR_CYAN}$1${COLOR_DEFAULT}"
 }
 
-# TODO:
-# #  SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-# doesn't work, throws bad substitution, it returns path to script (in this case aml
-# as a temporary hack I supply the SCRIPT DIR manually
-#if [ -z ${SCRIPT_DIR+x} ]; then
-##  SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-#  SCRIPT_DIR=`pwd`
-#fi
-
-# if the script is run with Jenkins, then set the SCRIPT_DIR manually, otherwise use the old way (does this work?)
+# if the script is run with Jenkins, then set the SCRIPT_DIR manually, otherwise use the old way
 if [[ -z "${JENKINS}" ]]; then
-  # JENKINS is undefined
+  # not run with JENKINS
   if [ -z ${SCRIPT_DIR+x} ]; then
   SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
   fi
 else
+  # run with JENKINS, need to set the SCRIPT_DIR in a different way, more manually
   SCRIPT_DIR=`pwd`
   SCRIPT_DIR=$SCRIPT_DIR/ampere_model_library
 fi
-
-
-#echo $SCRIPT_DIR
-#SCRIPT_DIR=$SCRIPT_DIR/ampere_model_library
-echo $SCRIPT_DIR
 
 
 log "Checking if setup has been completed ..."

--- a/utils/setup/gen_ld_preload.py
+++ b/utils/setup/gen_ld_preload.py
@@ -11,7 +11,7 @@ from pathlib import Path
 script_dir = os.path.dirname(os.path.realpath(__file__))
 ld_preload = list()
 
-for path in Path("/lib").rglob("libgomp*"):
+for path in Path("/").rglob("libgomp*"):
     if ".so" in path.name:
         ld_preload.append(str(path))
 

--- a/utils/setup/gen_ld_preload.py
+++ b/utils/setup/gen_ld_preload.py
@@ -11,7 +11,7 @@ from pathlib import Path
 script_dir = os.path.dirname(os.path.realpath(__file__))
 ld_preload = list()
 
-for path in Path("/").rglob("libgomp*"):
+for path in Path("/space/jenkins").rglob("libgomp*"):
     if ".so" in path.name:
         ld_preload.append(str(path))
 

--- a/utils/setup/gen_ld_preload.py
+++ b/utils/setup/gen_ld_preload.py
@@ -15,7 +15,9 @@ for path in Path("/lib").rglob("libgomp*"):
     if ".so" in path.name:
         ld_preload.append(str(path))
 
-for path in Path("/lib").rglob("libGLdispatch.so.0"):
+print(ld_preload)
+
+for path in Path("/").rglob("libGLdispatch.so.0"):
     ld_preload.append(str(path))
 
 # test the preload for errors
@@ -35,6 +37,7 @@ end_indices = [match.start() for match in re.finditer(end_pattern, errors)]
 for start, end in zip(start_indices, end_indices):
     ld_preload.remove(errors[start:end])
 
+print(ld_preload)
 f = open(os.path.join(script_dir, ".ld_preload"), "w")
 f.write(":".join(ld_preload))
 f.close()

--- a/utils/setup/gen_ld_preload.py
+++ b/utils/setup/gen_ld_preload.py
@@ -15,10 +15,14 @@ for path in Path("/lib").rglob("libgomp*"):
     if ".so" in path.name:
         ld_preload.append(str(path))
 
-print(ld_preload)
-
 for path in Path("/lib").rglob("libGLdispatch.so.0"):
     ld_preload.append(str(path))
+
+for path in Path("/root").rglob("libgomp*"):
+    if ".so" in path.name:
+        ld_preload.append(str(path))
+
+print(ld_preload)
 
 # test the preload for errors
 os.environ["LD_PRELOAD"] = ":".join(ld_preload)

--- a/utils/setup/gen_ld_preload.py
+++ b/utils/setup/gen_ld_preload.py
@@ -11,11 +11,11 @@ from pathlib import Path
 script_dir = os.path.dirname(os.path.realpath(__file__))
 ld_preload = list()
 
-for path in Path("/space/jenkins").rglob("libgomp*"):
+for path in Path("/lib").rglob("libgomp*"):
     if ".so" in path.name:
         ld_preload.append(str(path))
 
-for path in Path("/space/jenkins").rglob("libGLdispatch.so.0"):
+for path in Path("/lib").rglob("libGLdispatch.so.0"):
     ld_preload.append(str(path))
 
 # test the preload for errors

--- a/utils/setup/gen_ld_preload.py
+++ b/utils/setup/gen_ld_preload.py
@@ -12,6 +12,13 @@ script_dir = os.path.dirname(os.path.realpath(__file__))
 ld_preload = list()
 
 try:
+    for path in Path("/root").rglob("libgomp*"):
+        if ".so" in path.name:
+            ld_preload.append(str(path))
+except OSError as e:
+    print(e)
+
+try:
     for path in Path("/").rglob("libgomp*"):
         if ".so" in path.name:
             ld_preload.append(str(path))
@@ -29,12 +36,7 @@ except OSError as e:
     for path in Path("/lib").rglob("libGLdispatch.so.0"):
         ld_preload.append(str(path))
 
-try:
-    for path in Path("/root").rglob("libgomp*"):
-        if ".so" in path.name:
-            ld_preload.append(str(path))
-except OSError as e:
-    print(e)
+
 
 # test the preload for errors
 os.environ["LD_PRELOAD"] = ":".join(ld_preload)

--- a/utils/setup/gen_ld_preload.py
+++ b/utils/setup/gen_ld_preload.py
@@ -11,16 +11,30 @@ from pathlib import Path
 script_dir = os.path.dirname(os.path.realpath(__file__))
 ld_preload = list()
 
-for path in Path("/").rglob("libgomp*"):
-    if ".so" in path.name:
+try:
+    for path in Path("/").rglob("libgomp*"):
+        if ".so" in path.name:
+            ld_preload.append(str(path))
+except OSError as e:
+    print(e)
+    for path in Path("/lib").rglob("libgomp*"):
+        if ".so" in path.name:
+            ld_preload.append(str(path))
+
+try:
+    for path in Path("/").rglob("libGLdispatch.so.0"):
+        ld_preload.append(str(path))
+except OSError as e:
+    print(e)
+    for path in Path("/lib").rglob("libGLdispatch.so.0"):
         ld_preload.append(str(path))
 
-for path in Path("/lib").rglob("libGLdispatch.so.0"):
-    ld_preload.append(str(path))
-
-for path in Path("/root").rglob("libgomp*"):
-    if ".so" in path.name:
-        ld_preload.append(str(path))
+try:
+    for path in Path("/root").rglob("libgomp*"):
+        if ".so" in path.name:
+            ld_preload.append(str(path))
+except OSError as e:
+    print(e)
 
 print(ld_preload)
 

--- a/utils/setup/gen_ld_preload.py
+++ b/utils/setup/gen_ld_preload.py
@@ -36,8 +36,6 @@ try:
 except OSError as e:
     print(e)
 
-print(ld_preload)
-
 # test the preload for errors
 os.environ["LD_PRELOAD"] = ":".join(ld_preload)
 test_cmd = ["python3", "-c", "'print(\"AML\")'"]
@@ -55,7 +53,6 @@ end_indices = [match.start() for match in re.finditer(end_pattern, errors)]
 for start, end in zip(start_indices, end_indices):
     ld_preload.remove(errors[start:end])
 
-print(ld_preload)
 f = open(os.path.join(script_dir, ".ld_preload"), "w")
 f.write(":".join(ld_preload))
 f.close()

--- a/utils/setup/gen_ld_preload.py
+++ b/utils/setup/gen_ld_preload.py
@@ -17,7 +17,7 @@ for path in Path("/lib").rglob("libgomp*"):
 
 print(ld_preload)
 
-for path in Path("/").rglob("libGLdispatch.so.0"):
+for path in Path("/lib").rglob("libGLdispatch.so.0"):
     ld_preload.append(str(path))
 
 # test the preload for errors

--- a/utils/setup/gen_ld_preload.py
+++ b/utils/setup/gen_ld_preload.py
@@ -15,7 +15,7 @@ for path in Path("/space/jenkins").rglob("libgomp*"):
     if ".so" in path.name:
         ld_preload.append(str(path))
 
-for path in Path("/").rglob("libGLdispatch.so.0"):
+for path in Path("/space/jenkins").rglob("libGLdispatch.so.0"):
     ld_preload.append(str(path))
 
 # test the preload for errors


### PR DESCRIPTION
what changed:

I expanded the python functions for searching for libgomp packages. On Jenkins searching from "/" doesn't work as expected so I added try except to resolve that issue. Ideally we could investigate why the process throws an OSError.

in set_env.sh I added a case for Jenkins, for some reason Jenkins has a problem with the syntax in bash, so my solution was to declare a JENKINS variable inside groovy, then a jenkins scenario will be run inside bash with a different syntax, (but doing the same thing). Ideally we could also investigate why this syntax error appears. Perhaps there is some specific version of bash, or something that emulates bash but is not in fact bash? Either way, it was beyond my expertise, perhaps Kuba would know more. 