### PR TITLE
Need to initialize LD_PRELOAD before running install framework python

### DIFF
--- a/setup_deb.sh
+++ b/setup_deb.sh
@@ -46,7 +46,6 @@ log "done.\n"
 
 log "Setup LD_PRELOAD ..."
 sleep 1
-ARCH=$( uname -m )
 if [ "${ARCH}" = "aarch64" ]; then
    python3 $SCRIPT_DIR/utils/setup/gen_ld_preload.py
    LD_PRELOAD=`cat $SCRIPT_DIR/utils/setup/.ld_preload`

--- a/setup_deb.sh
+++ b/setup_deb.sh
@@ -44,6 +44,17 @@ apt-get update -y
 apt-get install -y python3 python3-pip ffmpeg libsm6 libxext6 wget
 log "done.\n"
 
+log "Setup LD_PRELOAD ..."
+sleep 1
+ARCH=$( uname -m )
+if [ "${ARCH}" = "aarch64" ]; then
+   python3 $SCRIPT_DIR/utils/setup/gen_ld_preload.py
+   LD_PRELOAD=`cat $SCRIPT_DIR/utils/setup/.ld_preload`
+   echo "LD_PRELOAD=$LD_PRELOAD"
+fi
+export LD_PRELOAD=$LD_PRELOAD
+log "done.\n"
+
 log "Installing python dependencies ..."
 sleep 1
 if [ "${ARCH}" == "aarch64" ]; then


### PR DESCRIPTION
Fix CI failure where it fails when calling install framework

OSError: /root/miniforge3/envs/tensorflow/lib/python3.8/site-packages/torch/lib/libgomp-d22c30c5.so.1: cannot allocate memory in static TLS block