### PR TITLE
add build-essential and python*-dev to setup_deb.sh

### DIFF
--- a/setup_deb.sh
+++ b/setup_deb.sh
@@ -41,7 +41,9 @@ fi
 log "Installing system dependencies ..."
 sleep 1
 apt-get update -y
-apt-get install -y python3 python3-pip ffmpeg libsm6 libxext6 wget
+apt-get install -y python3 python3-pip build-essential ffmpeg libsm6 libxext6 wget
+PYTHON_VERSION=$(python3 -c 'import sys; print(".".join(map(str, sys.version_info[0:2])))')
+apt-get -y install python${PYTHON_VERSION}-dev
 log "done.\n"
 
 log "Setup LD_PRELOAD ..."


### PR DESCRIPTION
Building Python wheels of dependencies fails on system without gcc and Python header files installed. 
https://github.com/AmpereComputingAI/model_zoo_dev/issues/100

To fix the first problem, this PR adds `build-essential` to the list of installed packages. To fix the second problem the `python*-dev` package needs to be installed. Installing `python3-dev` doesn't solve the issue, so we need to detect the installed version of Python and install the appropriate version of the dev package eg. `python3.9-dev`.