### PR TITLE
check if python*-dev available before install

### DIFF
--- a/setup_deb.sh
+++ b/setup_deb.sh
@@ -43,7 +43,10 @@ sleep 1
 apt-get update -y
 apt-get install -y python3 python3-pip build-essential ffmpeg libsm6 libxext6 wget
 PYTHON_VERSION=$(python3 -c 'import sys; print(".".join(map(str, sys.version_info[0:2])))')
-apt-get -y install python${PYTHON_VERSION}-dev
+PYTHON_DEV_SEARCH=$(apt-cache search --names-only "python${PYTHON_VERSION}-dev")
+if [[ -n "$PYTHON_DEV_SEARCH"  ]]; then
+	apt-get -y install "python${PYTHON_VERSION}-dev"
+fi
 log "done.\n"
 
 log "Setup LD_PRELOAD ..."


### PR DESCRIPTION
https://github.com/AmpereComputingAI/ampere_model_library/pull/165 fixed `python*-dev` issue in some docker containers, but broke it in others. This PR fixes that.

Specifically, in `arm_tf2:8d1fa7f` running `bash setup_deb.sh` would result in a crash due to not being able to locate the package. The docker image is based on Ubuntu 20.04, where only `python3.8-dev` and `python3.9-dev` are available, but the installed version of Python is 3.10.8. Installing `python3.10-dev` is not needed though, as the packages are built without issues, so the header files must already be present despite not being able to install the package.

Now we first check if the `python*-dev` package for the installed version of Python is available before trying to install it. In case it is not, we skip it.

We have 4 cases:
- Can't install, don't need to -> Can skip [This PR, previously would crash]
- Can't install, needs to -> Will still crash later, same as before #165. Should be incredibly rare or impossible
- Can install, don't need to -> Don't care (it will mark the package as manually installed)
- Can install, needs to -> Install [fixed by https://github.com/AmpereComputingAI/ampere_model_library/pull/165]