### PR TITLE
Update set_env_variables.sh

### DIFF
--- a/set_env_variables.sh
+++ b/set_env_variables.sh
@@ -16,7 +16,7 @@ log "Checking if setup has been completed ..."
 sleep 1
 if ! [ -f "$SCRIPT_DIR/.setup_completed" ]; then
    log "\nPlease complete setup first by running: 'bash setup_deb.sh'! Quitting."
-   exit 1
+   return
 fi
 log "done.\n"
 


### PR DESCRIPTION
If somebody run `source set_env_variables.sh` prior to setup_deb.sh an exit call caused his shell to close :) this simple change fixes that