### PR TITLE
Add options for torch.compile AIO backend

### DIFF
--- a/utils/pytorch.py
+++ b/utils/pytorch.py
@@ -45,7 +45,7 @@ class PyTorchRunner:
             if os.environ.get("TORCH_COMPILE") == "1" and version.parse(pkg_resources.get_distribution("torch").version) >= version.parse("1.14"):
                 # More natural comparison to version.parse("2.0") returns False for 2.0.0a0+git07156c4.dev, which is wrong.
                 # There was never a PyTorch 1.14, so this comparison acts like comparing to 2.0, but works correctly for such edge cases.
-                self.__frozen_script = torch.compile(self.__model, backend="aio" if AIO else "inductor")
+                self.__frozen_script = torch.compile(self.__model, backend="aio" if AIO else "inductor", options={"modelname", self.__model._get_name()} if AIO else {})
             elif os.environ.get("TORCH_COMPILE") == "1" and not version.parse(pkg_resources.get_distribution("torch").version) >= version.parse("1.14"):
                 utils.print_goodbye_message_and_die(f"TORCH_COMPILE=1 set, but installed PyTorch version is {pkg_resources.get_distribution('torch').version}. PyTorch version must be at least 2.0.0 to use torch.compile().")
             elif cached_path.exists():


### PR DESCRIPTION
PR https://github.com/AmpereComputingAI/pytorch-dls/commit/1938e1fb42d2a931a79976824f80c1ab91a997a5 introduces mandatory options field for AIO backend in torch.compile call. User has to pass parameter "modelname" with some string value.

AIO backend uses this options to differentiate between different models in its cache. Cache is used for speeding up compilation and reducing memory usage of some models. Especially those with encoder-decoder architecture.