### PR TITLE
return the result

### DIFF
--- a/natural_language_processing/text_generation/alpaca/run.py
+++ b/natural_language_processing/text_generation/alpaca/run.py
@@ -35,7 +35,7 @@ def run_pytorch(model_path, num_runs, timeout, dataset_path, disable_jit_freeze=
 
 
 def run_pytorch_fp32(model_path, num_runs, timeout, dataset_path, disable_jit_freeze=False, **kwargs):
-    run_pytorch(model_path, num_runs, timeout, dataset_path, disable_jit_freeze, **kwargs)
+    return run_pytorch(model_path, num_runs, timeout, dataset_path, disable_jit_freeze, **kwargs)
 
 
 def main():


### PR DESCRIPTION
Lack of the `return` keyword was making wrappers using this functionality fail, because they were receiving `None` instead of the correct result