### PR TITLE
Add switch to use Pytorch fp16 mode

### DIFF
--- a/natural_language_processing/text_generation/alpaca/run.py
+++ b/natural_language_processing/text_generation/alpaca/run.py
@@ -3,7 +3,7 @@ from utils.pytorch import PyTorchRunnerV2, apply_compile
 from utils.benchmark import run_model
 
 
-def run_pytorch(model_path, num_runs, timeout, dataset_path):
+def run_pytorch(model_path, num_runs, timeout, dataset_path, use_torch_fp16=False):
     from transformers import AutoModelForCausalLM, AutoTokenizer
   
     def run_single_pass(pytorch_runner, _dataset):
@@ -14,7 +14,8 @@ def run_pytorch(model_path, num_runs, timeout, dataset_path):
         _dataset.submit_prediction(response)
 
     model = AutoModelForCausalLM.from_pretrained(model_path)
-    model.merge_qkv()
+    if use_torch_fp16:
+        model = model.half()
     model.eval()
     model.greedy_search = apply_compile(model.greedy_search)
 
@@ -29,10 +30,13 @@ def run_pytorch(model_path, num_runs, timeout, dataset_path):
 
 
 def run_pytorch_fp32(model_path, num_runs, timeout, dataset_path, **kwargs):
-    return run_pytorch(model_path, num_runs, timeout, dataset_path)
+    return run_pytorch(model_path, num_runs, timeout, dataset_path, use_torch_fp16=False)
+
+def run_pytorch_fp16(model_path, num_runs, timeout, dataset_path, **kwargs):
+    return run_pytorch(model_path, num_runs, timeout, dataset_path, use_torch_fp16=True)
 
   
-def run_pytorch_cuda(model_path, num_runs, timeout, dataset_path, disable_jit_freeze=False, **kwargs):
+def run_pytorch_cuda(model_path, num_runs, timeout, dataset_path, **kwargs):
     from transformers import AutoModelForCausalLM, AutoTokenizer
 
     def run_single_pass(pytorch_runner, dataset):


### PR DESCRIPTION
Rationale: some models support Pytorch native FP16 mode. It is preferable to use it over Implicit mode, especially with decoder models due to much less time spent on conversions.

Also removing merge_qkv(): right now it is implemented in Pytorch connector in better way. 
This PR has to be merged alongside with https://github.com/AmpereComputingAI/transformers/pull/2