### PR TITLE
add **kwargs

### DIFF
--- a/computer_vision/semantic_segmentation/unet_3d/brats_19/run.py
+++ b/computer_vision/semantic_segmentation/unet_3d/brats_19/run.py
@@ -61,15 +61,15 @@ def run_tf_fp(model_path, num_runs, timeout, dataset_path):
     return run_model(run_single_pass, runner, dataset, 1, num_runs, timeout)
 
 
-def run_tf_fp32(model_path, num_runs, timeout, dataset_path):
+def run_tf_fp32(model_path, num_runs, timeout, dataset_path, **kwargs):
     return run_tf_fp(model_path, num_runs, timeout, dataset_path)
 
 
-def run_tf_fp16(model_path, num_runs, timeout, dataset_path):
+def run_tf_fp16(model_path, num_runs, timeout, dataset_path, **kwargs):
     return run_tf_fp(model_path, num_runs, timeout, dataset_path)
 
 
-def run_pytorch_fp32(model_path, num_runs, timeout, dataset_path):
+def run_pytorch_fp32(model_path, num_runs, timeout, dataset_path, **kwargs):
     import torch
     import numpy as np
     from utils.cv.brats import BraTS19


### PR DESCRIPTION
Currently run.py script for the Brats model fails, because it requires the precision to be passed as an argument and then passes all the arguments it received to a function through `**vars(args)`, but the functions like `run_pytorch_fp32` don't accept precision argument and they fail with `TypeError: run_pytorch_fp32() got an unexpected keyword argument 'precision'`. This works around this issue.