### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -35,3 +35,4 @@ kornia
 open-clip-torch<2.26.1
 diffusers
 accelerate
+boto3==1.29.0; python_version>='3.12'


### PR DESCRIPTION
botocore throws an error on Python 3.12 builds. This version of boto3 should install a botocore version compatible with Python 3.12